### PR TITLE
fix bower.json references

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,10 @@
     "Niall Crosby <info@angulargrid.com>"
   ],
   "description": "High performance and feature rich data grid for AngularJS",
-  "main": "main.js",
+  "main": [
+    "dist/angularGrid.js",
+    "dist/angularGrid.css"
+  ],
   "moduleType": [
     "node"
   ],


### PR DESCRIPTION
I use an automatic wiring logic based on bower.json meta information. It would be nice if you could merge this fix.
Thanks