### PR TITLE
Fix pagination error when rowCount is null

### DIFF
--- a/src/js/paginationController.js
+++ b/src/js/paginationController.js
@@ -41,7 +41,7 @@ PaginationController.prototype.reset = function() {
     // copy pageSize, to guard against it changing the the datasource between calls
     this.pageSize = this.datasource.pageSize;
     // see if we know the total number of pages, or if it's 'to be decided'
-    if (this.datasource.rowCount >= 0) {
+    if (typeof this.datasource.rowCount === 'number' && this.datasource.rowCount >= 0) {
         this.rowCount = this.datasource.rowCount;
         this.foundMaxRow = true;
         this.calculateTotalPages();


### PR DESCRIPTION
When pagination is enabled and `rowCount` is null, `calculateTotalPages()` blows up because of the check in this line. This fix makes sure that `rowCount` is always a number.