### PR TITLE
Scroll to Column #137

### DIFF
--- a/src/js/grid.js
+++ b/src/js/grid.js
@@ -381,7 +381,7 @@ Grid.prototype.ensureNodeVisible = function(comparator) {
     }
 };
 
-Grid.prototype.ensureIndexVisible = function(index) {
+Grid.prototype.ensureIndexVisible = function(index, colIndex) {
     var lastRow = this.rowModel.getVirtualRowCount();
     if (typeof index !== 'number' || index < 0 || index >= lastRow) {
         throw 'invalid row index for ensureIndexVisible: ' + index;
@@ -411,6 +411,43 @@ Grid.prototype.ensureIndexVisible = function(index) {
         this.eBodyViewport.scrollTop = newScrollPosition;
     }
     // otherwise, row is already in view, so do nothing
+
+    // Optional colIndex paramater
+    if (typeof colIndex !== 'number')
+        return;
+
+    var columnDefs = this.gridOptionsWrapper.getColumnDefs();
+
+    if (colIndex < 0 || colIndex >= columnDefs.length) {
+        throw 'invalid column index for ensureIndexVisible: ' + colIndex;
+    }
+  
+    var colWidth = this.gridOptionsWrapper.getColWidth();
+    var colRightPixel = colWidth * colIndex;
+    var colLeftPixel = colRightPixel - colWidth;
+
+    var viewportLeftPixel = this.eBodyViewport.scrollLeft;
+    var viewportWidth = this.eBodyViewport.offsetWidth;
+
+    scrollShowing = this.eBodyViewport.clientHeight < this.eBodyViewport.scrollHeight;
+    if (scrollShowing) {
+        viewportWidth -= this.scrollWidth;
+    }
+   
+    var viewportRightPixel = viewportLeftPixel + viewportWidth;
+
+    var viewportScrolledPastCol = viewportLeftPixel > colLeftPixel;
+    var viewportScrolledBeforeCol = viewportRightPixel < colRightPixel;
+
+    if (viewportScrolledPastCol) {
+        // if viewport's left side is after col's left side, scroll right to pull col into viewport at left
+        this.eBodyViewport.scrollLeft = colLeftPixel;
+    } else if (viewportScrolledBeforeCol) {
+        // if viewport's right side is before col's right side, scroll left to pull col into viewport at right
+        var newScrollPosition = colRightPixel - viewportWidth;
+        this.eBodyViewport.scrollLeft = newScrollPosition;
+    }
+    // otherwise, col is already in view, so do nothing
 };
 
 Grid.prototype.addApi = function() {
@@ -516,8 +553,8 @@ Grid.prototype.addApi = function() {
         getBestCostNodeSelection: function() {
             return that.selectionController.getBestCostNodeSelection();
         },
-        ensureIndexVisible: function(index) {
-            return that.ensureIndexVisible(index);
+        ensureIndexVisible: function(index, colIndex) {
+            return that.ensureIndexVisible(index, colIndex);
         },
         ensureNodeVisible: function(comparator) {
             return that.ensureNodeVisible(comparator);


### PR DESCRIPTION
I take a quick look at how you implemented the row scroll via ensureIndexVisible(index), and provide a similar implementation for the column scroll. I modify ensureIndexVisible method to pass in an optional colIndex parameter. I tested and verify that this change works well for me, so I just want to share the code changes for you to review (and to include in next release if you are ok with it).

I did not change the original "index" parameter name to "rowIndex", so please update the parameter name as you see fit. 