### PR TITLE
UnSort Icon

### DIFF
--- a/docs/angular-grid-column-definitions/index.php
+++ b/docs/angular-grid-column-definitions/index.php
@@ -93,6 +93,10 @@ include '../documentation_header.php';
             <td>Set to true if no sorting should be done for this column.</td>
         </tr>
         <tr>
+            <th>unSortIcon</th>
+            <td>Set to true if you want the unsorted icon to be shown when no sort is applied to this column.</td>
+        </tr>
+        <tr>
             <th>suppressSizeToFit</th>
             <td>Set to true if you want this columns width to be fixed during 'size to fit' operation.</td>
         </tr>

--- a/docs/angular-grid-icons/index.php
+++ b/docs/angular-grid-icons/index.php
@@ -45,6 +45,7 @@ gridOptions.icons = {
     filter: myFilterIcon,
     sortAscending: mySortAscIcon,
     sortDescending: mySortDescIcon,
+    sortUnSort: myUnSortIcon,
     groupExpanded: myGroupExpandedIcon,
     groupContracted: myGroupContractedIcon,
     headerGroupOpened: myGroupExpandedIcon,

--- a/docs/angular-grid-sorting/example1.js
+++ b/docs/angular-grid-sorting/example1.js
@@ -7,7 +7,7 @@ module.controller("exampleCtrl", function($scope, $http) {
         {headerName: "Athlete", field: "athlete", width: 150},
         {headerName: "Age", field: "age", width: 90},
         {headerName: "Country", field: "country", width: 120},
-        {headerName: "Year", field: "year", width: 90},
+        {headerName: "Year", field: "year", width: 90, unSortIcon: true},
         {headerName: "Date", field: "date", width: 110, comparator: dateComparator},
         {headerName: "Sport", field: "sport", width: 110},
         {headerName: "Gold", field: "gold", width: 100},

--- a/src/js/headerRenderer.js
+++ b/src/js/headerRenderer.js
@@ -248,10 +248,18 @@ HeaderRenderer.prototype.createHeaderCell = function(column, grouped, headerGrou
     if (this.gridOptionsWrapper.isEnableSorting() && !colDef.suppressSorting) {
         column.eSortAsc = utils.createIcon('sortAscending', this.gridOptionsWrapper, column, svgFactory.createArrowUpSvg);
         column.eSortDesc = utils.createIcon('sortDescending', this.gridOptionsWrapper, column, svgFactory.createArrowDownSvg);
-        utils.addCssClass(column.eSortAsc, 'ag-header-icon');
-        utils.addCssClass(column.eSortDesc, 'ag-header-icon');
+        utils.addCssClass(column.eSortAsc, 'ag-header-icon sortAscending');
+        utils.addCssClass(column.eSortDesc, 'ag-header-icon sortDescending');
         headerCellLabel.appendChild(column.eSortAsc);
         headerCellLabel.appendChild(column.eSortDesc);
+
+        // Unsort icon
+        if (colDef.unSortIcon) {
+          column.eSortUnsort = utils.createIcon('sortUnSort', this.gridOptionsWrapper, column, svgFactory.createArrowUpDownSvg);
+          utils.addCssClass(column.eSortUnsort, 'ag-header-icon sortUnSort');
+          headerCellLabel.appendChild(column.eSortUnsort);
+        }
+
         column.eSortAsc.style.display = 'none';
         column.eSortDesc.style.display = 'none';
         this.addSortHandling(headerCellLabel, column);
@@ -396,12 +404,17 @@ HeaderRenderer.prototype.updateSortIcons = function() {
         // update visibility of icons
         var sortAscending = column.sort === constants.ASC;
         var sortDescending = column.sort === constants.DESC;
+        var unSort = column.sort !== constants.DESC && column.sort !== constants.ASC;
 
         if (column.eSortAsc) {
             utils.setVisible(column.eSortAsc, sortAscending);
         }
         if (column.eSortDesc) {
             utils.setVisible(column.eSortDesc, sortDescending);
+        }
+        // UnSort Icon
+        if (column.eSortUnsort) {
+          utils.setVisible(column.eSortUnsort, unSort);
         }
     });
 };

--- a/src/js/svgFactory.js
+++ b/src/js/svgFactory.js
@@ -59,6 +59,21 @@ SvgFactory.prototype.createSmallArrowDownSvg = function() {
     return createPolygonSvg("0,0 3,6 6,0", 6);
 };
 
+// UnSort Icon SVG
+SvgFactory.prototype.createArrowUpDownSvg = function() {
+    var svg = createIconSvg();
+
+    var eAscIcon = document.createElementNS(SVG_NS, "polygon");
+    eAscIcon.setAttribute("points", '0,4 5,0 10,4');
+    svg.appendChild(eAscIcon);
+
+    var eDescIcon = document.createElementNS(SVG_NS, "polygon");
+    eDescIcon.setAttribute("points", '0,6 5,10 10,6');
+    svg.appendChild(eDescIcon);
+
+    return svg;
+};
+
 function createPolygonSvg(points, width) {
     var eSvg = createIconSvg(width);
 


### PR DESCRIPTION
Hi. I implemented an optional icon when a column is unsorted (activated at a column level). This is popular with [other grids](https://www.datatables.net/examples/basic_init/table_sorting.html)

Summary of changes:
- Add class to Asc & Desc Icons containers (to style them better)
- Add unSortIcon option to columns: if true an unSort Icon is shown when the column is not sorted
- Icon can be customised with gridOptions.icon.sortUnSort (excellent to use something like `<i class="fa fa-sort"></i>` from font-awesome
- Add SVG factory for the unSort Icon
- Adjusted Documentation (including one example)

