### PR TITLE
Some typescript definitions

### DIFF
--- a/src/ts/columnController.ts
+++ b/src/ts/columnController.ts
@@ -615,12 +615,136 @@ module awk.grid {
             }
         }
     }
+    
+    export interface CellRendererObj {
+      renderer: string;
+    }
+
+    /** The filter parameters for set filter */
+    export interface SetFilterParameters{
+      /** Same as cell renderer for grid (you can use the same one in both locations). Setting it separatly here allows for the value to be rendered differently in the filter. */
+      cellRenderer ?: Function;
+        
+      /** The height of the cell. */
+      cellHeight ?: number;
+
+      /** The values to display in the filter. */
+      values ?: any;
+
+      /**  What to do when new rows are loaded. The default is to reset the filter, as the set of values to select from can have changed. If you want to keep the selection, then set this value to 'keep'. */
+      newRowsAction ?: string;
+    }
+
+    
+    export interface TextAndNumberFilterParameters {
+      /** What to do when new rows are loaded. The default is to reset the filter, to keep it in line with 'set' filters. If you want to keep the selection, then set this value to 'keep'. */
+      newRowsAction?: string;
+    }
+
+    export interface ColDef {
+      /** The name to render in the column header */
+      headerName: string;
+      
+      /** The field of the row to get the cells data from */
+      field: string;
+      
+      /** Expression or function to get the cells value. */
+      headerValueGetter?: string | Function;
+      
+      /** The unique ID to give the column. This is optional. If missing, the ID will default to the field. If both field and colId are missing, a unique ID will be generated. 
+       *  This ID is used to identify the column in the API for sorting, filtering etc. */
+      colId?: string;
+      
+      /** Set to true for this column to be hidden. Naturally you might think, it would make more sense to call this field 'visible' and mark it false to hide, 
+       *  however we want all default values to be false and we want columns to be visible by default. */
+      hide?: boolean;
+
+      /** Tooltip for the column header */
+      headerTooltip?: string;
+
+      /** Expression or function to get the cells value. */
+      valueGetter?: string | Function;
+
+      /** Initial width, in pixels, of the cell */
+      width?: number;
+
+      /** Class to use for the cell. Can be string, array of strings, or function. */
+      cellClass?: string | string[]| ((cellClassParams: any) => string | string[]);
+      
+      /** An object of css values. Or a function returning an object of css values. */
+      cellStyle?: {} | ((params: any) => {});
+
+      /** A function for rendering a cell. */
+      cellRenderer?: Function | CellRendererObj;
+
+      /** Function callback, gets called when a cell is clicked. */
+      cellClicked?: Function;
+
+      /** Function callback, gets called when a cell is double clicked. */
+      cellDoubleClicked?: Function;
+
+      /** Name of function to use for aggregation. One of [sum,min,max]. */
+      aggFunc?: string;
+
+      /** Comparator function for custom sorting. */
+      comparator?: Function;
+
+      /** Set to true to render a selection checkbox in the column. */
+      checkboxSelection?: boolean;
+
+      /** Set to true if no menu should be shown for this column header. */
+      suppressMenu?: boolean;
+
+      /** Set to true if no sorting should be done for this column. */
+      suppressSorting?: boolean;
+
+      /** Set to true if you want the unsorted icon to be shown when no sort is applied to this column. */
+      unSortIcon?: boolean;
+
+      /** Set to true if you want this columns width to be fixed during 'size to fit' operation. */
+      suppressSizeToFit?: boolean;
+
+      /** Set to true if you do not want this column to be resizable by dragging it's edge. */
+      suppressResize?: boolean;
+
+      /** If grouping columns, the group this column belongs to. */
+      headerGroup?: string;
+
+      /** Whether to show the column when the group is open / closed. */
+      headerGroupShow?: boolean;
+      
+      /** Set to true if this col is editable, otherwise false. Can also be a function to have different rows editable. */
+      editable?: boolean | (Function);
+
+      /** Callbacks for editing.See editing section for further details. */
+      newValueHandler?: Function;
+
+      /** Callbacks for editing.See editing section for further details. */
+      cellValueChanged?: Function;
+
+      /** If true, this cell gets refreshed when api.softRefreshView() gets called. */
+      volatile?: boolean;
+      
+      /** Cell template to use for cell. Useful for AngularJS cells. */
+      template?: string;
+
+      /** Cell template URL to load template from to use for cell. Useful for AngularJS cells. */
+      templateUrl?: string;
+
+      /** one of the built in filter names: [set, number, text], or a filter function*/
+      filter?: string | Function;
+
+      /** The filter params are specific to each filter! */
+      filterParams?: SetFilterParameters | TextAndNumberFilterParameters;
+
+      cellClassRules?: { [cssClassName: string]: (Function | string) };
+    }
 
     export class Column {
 
         static colIdSequence = 0;
 
-        colDef: any;
+        colDef: ColDef;
         actualWidth: any;
         visible: any;
         colId: any;
@@ -629,7 +753,7 @@ module awk.grid {
         aggFunc: string;
         pivotIndex: number;
 
-        constructor(colDef: any, actualWidth: any) {
+        constructor(colDef: ColDef, actualWidth: any) {
             this.colDef = colDef;
             this.actualWidth = actualWidth;
             this.visible = !colDef.hide;

--- a/src/ts/filter/filterManager.ts
+++ b/src/ts/filter/filterManager.ts
@@ -35,7 +35,7 @@ module awk.grid {
             if (model) {
                 // mark the filters as we set them, so any active filters left over we stop
                 var processedFields = Object.keys(model);
-                utils.iterateObject(this.allFilters, function (key: any, filterWrapper: any) {
+                utils.iterateObject(this.allFilters, function (key, filterWrapper) {
                     var field = filterWrapper.column.colDef.field;
                     utils.removeFromArray(processedFields, field);
                     if (field) {
@@ -46,7 +46,7 @@ module awk.grid {
                     }
                 });
                 // at this point, processedFields contains data for which we don't have a filter working yet
-                utils.iterateArray(processedFields, function (field: any) {
+                utils.iterateArray(processedFields, function (field) {
                     var column = that.columnModel.getColumn(field);
                     if (!column) {
                         console.warn('Warning ag-grid - no column found for field ' + field);
@@ -56,13 +56,13 @@ module awk.grid {
                     that.setModelOnFilterWrapper(filterWrapper.filter, model[field]);
                 });
             } else {
-                utils.iterateObject(this.allFilters, function (key: any, filterWrapper: any) {
+                utils.iterateObject(this.allFilters, function (key, filterWrapper) {
                     that.setModelOnFilterWrapper(filterWrapper.filter, null);
                 });
             }
         }
 
-        private setModelOnFilterWrapper(filter: any, newModel: any) {
+        private setModelOnFilterWrapper(filter: { getApi: () => { setModel: Function }}, newModel: any) {
             // because user can provide filters, we provide useful error checking and messages
             if (typeof filter.getApi !== 'function') {
                 console.warn('Warning ag-grid - filter missing getApi method, which is needed for getFilterModel');
@@ -184,7 +184,7 @@ module awk.grid {
             };
         }
 
-        public getFilterApi(column: any) {
+        public getFilterApi(column: Column) {
             var filterWrapper = this.getOrCreateFilterWrapper(column);
             if (filterWrapper) {
                 if (typeof filterWrapper.filter.getApi === 'function') {
@@ -193,7 +193,7 @@ module awk.grid {
             }
         }
 
-        private getOrCreateFilterWrapper(column: any) {
+        private getOrCreateFilterWrapper(column: Column) {
             var filterWrapper = this.allFilters[column.colId];
 
             if (!filterWrapper) {
@@ -204,7 +204,7 @@ module awk.grid {
             return filterWrapper;
         }
 
-        private createFilterWrapper(column: any) {
+        private createFilterWrapper(column: Column) {
             var colDef = column.colDef;
 
             var filterWrapper = {
@@ -232,8 +232,8 @@ module awk.grid {
                     filterWrapper.scope = scope;
                     params.$scope = scope;
                 }
-                // now create filter
-                filterWrapper.filter = new colDef.filter(params);
+                // now create filter (had to cast to any to get 'new' working)
+                filterWrapper.filter = new (<any>colDef.filter)(params);
             } else if (colDef.filter === 'text') {
                 filterWrapper.filter = new TextFilter(params);
             } else if (colDef.filter === 'number') {
@@ -268,7 +268,7 @@ module awk.grid {
             return filterWrapper;
         }
 
-        private showFilter(column: any, eventSource: any) {
+        private showFilter(column: Column, eventSource: any) {
 
             var filterWrapper = this.getOrCreateFilterWrapper(column);
 

--- a/src/ts/renderedCell.ts
+++ b/src/ts/renderedCell.ts
@@ -33,7 +33,7 @@ module awk.grid {
         private selectionController: SelectionController;
         private $compile: any;
         private templateService: TemplateService;
-        private cellRendererMap: {[key: string]: any};
+        private cellRendererMap: {[key: string]: Function};
 
         constructor(isFirstColumn: any, column: any, node: any, rowIndex: number,
                     scope: any, $compile: any, rowRenderer: RowRenderer,
@@ -265,7 +265,8 @@ module awk.grid {
             // if function, then call the function to find out
             if (typeof colDef.editable === 'function') {
                 // should change this, so it gets passed params with nice useful values
-                return colDef.editable(this.node.data);
+                var editableFunc = <Function>colDef.editable;
+                return editableFunc(this.node.data);
             }
 
             return false;
@@ -334,8 +335,9 @@ module awk.grid {
                         $scope: this.scope,
                         context: this.gridOptionsWrapper.getContext(),
                         api: this.gridOptionsWrapper.getApi()
-                    };
-                    cssToUse = colDef.cellStyle(cellStyleParams);
+                  };             
+                    var cellStyleFunc = <Function>colDef.cellStyle;     
+                    cssToUse = cellStyleFunc(cellStyleParams);
                 } else {
                     cssToUse = colDef.cellStyle;
                 }
@@ -349,7 +351,8 @@ module awk.grid {
         private addClassesFromCollDef(value: any) {
             var colDef = this.column.colDef;
             if (colDef.cellClass) {
-                var classToUse: any;
+              var classToUse: any;
+
                 if (typeof colDef.cellClass === 'function') {
                     var cellClassParams = {
                         value: value,
@@ -360,7 +363,8 @@ module awk.grid {
                         context: this.gridOptionsWrapper.getContext(),
                         api: this.gridOptionsWrapper.getApi()
                     };
-                    classToUse = colDef.cellClass(cellClassParams);
+                    var cellClassFunc = <(cellClassParams: any) => string|string[]> colDef.cellClass;
+                    classToUse = cellClassFunc(cellClassParams);
                 } else {
                     classToUse = colDef.cellClass;
                 }
@@ -537,14 +541,15 @@ module awk.grid {
                 refreshCell: refreshCellFunction,
                 eGridCell: this.eGridCell
             };
-            var cellRenderer: any;
+            var cellRenderer: Function;
             if (typeof colDef.cellRenderer === 'object' && colDef.cellRenderer !== null) {
-                cellRenderer = this.cellRendererMap[colDef.cellRenderer.renderer];
+                var cellRendererObj = <{ renderer: string }> colDef.cellRenderer;
+                cellRenderer = this.cellRendererMap[cellRendererObj.renderer];
                 if (!cellRenderer) {
                     throw 'Cell renderer ' + colDef.cellRenderer + ' not found, available are ' + Object.keys(this.cellRendererMap);
                 }
             } else if (typeof colDef.cellRenderer === 'function') {
-                cellRenderer = colDef.cellRenderer;
+                cellRenderer = <Function>colDef.cellRenderer;
             } else {
                 throw 'Cell Renderer must be String or Function';
             }

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -6,7 +6,7 @@ module awk.grid {
 
     export class Utils {
 
-        static iterateObject(object: any, callback: any) {
+        static iterateObject(object: any, callback: (key:string, value: any) => void) {
             var keys = Object.keys(object);
             for (var i = 0; i < keys.length; i++) {
                 var key = keys[i];
@@ -15,8 +15,8 @@ module awk.grid {
             }
         }
 
-        static map(array: any, callback: any) {
-            var result: any = [];
+        static map<TItem, TResult>(array: TItem[], callback: (item: TItem) => TResult) {
+            var result: TResult[] = [];
             for (var i = 0; i < array.length; i++) {
                 var item = array[i];
                 var mappedItem = callback(item);
@@ -25,7 +25,7 @@ module awk.grid {
             return result;
         }
 
-        static forEach(array: any, callback: any) {
+        static forEach<T>(array: T[], callback: (item: T, index: number) => void) {
             if (!array) {
                 return;
             }
@@ -58,8 +58,8 @@ module awk.grid {
             return null;
         }
 
-        static toStrings(array: any) {
-            return this.map(array, function (item: any) {
+        static toStrings<T>(array: T[]): string[] {
+            return this.map(array, function (item) {
                 if (item === undefined || item === null || !item.toString) {
                     return null;
                 } else {
@@ -68,7 +68,7 @@ module awk.grid {
             });
         }
 
-        static iterateArray(array: any, callback: any) {
+        static iterateArray<T>(array: T[], callback: (item: T, index: number) => void) {
             for (var index = 0; index < array.length; index++) {
                 var value = array[index];
                 callback(value, index);
@@ -129,7 +129,7 @@ module awk.grid {
         }
 
         //adds all type of change listeners to an element, intended to be a text field
-        static addChangeListener(element: any, listener: any) {
+        static addChangeListener(element: HTMLElement, listener: EventListener) {
             element.addEventListener("changed", listener);
             element.addEventListener("paste", listener);
             element.addEventListener("input", listener);
@@ -144,7 +144,7 @@ module awk.grid {
             }
         }
 
-        static removeAllChildren(node: any) {
+        static removeAllChildren(node: HTMLElement) {
             if (node) {
                 while (node.hasChildNodes()) {
                     node.removeChild(node.lastChild);
@@ -152,43 +152,45 @@ module awk.grid {
             }
         }
 
-        static removeElement(parent: any, cssSelector: string) {
+        static removeElement(parent: HTMLElement, cssSelector: string) {
             this.removeFromParent(parent.querySelector(cssSelector));
         }
 
-        static removeFromParent(node: any) {
+        static removeFromParent(node: Element) {
             if (node && node.parentNode) {
                 node.parentNode.removeChild(node);
             }
         }
 
-        static isVisible(element: any) {
+        static isVisible(element: HTMLElement) {
             return (element.offsetParent !== null)
         }
 
-        //loads the template and returns it as an element. makes up for no simple way in
-        //the dom api to load html directly, eg we cannot do this: document.createElement(template)
-        static loadTemplate(template: any) {
+        /** 
+         * loads the template and returns it as an element. makes up for no simple way in
+         * the dom api to load html directly, eg we cannot do this: document.createElement(template) 
+         */
+        static loadTemplate(template: string) {
             var tempDiv = document.createElement("div");
             tempDiv.innerHTML = template;
             return tempDiv.firstChild;
         }
 
-        static querySelectorAll_addCssClass(eParent: any, selector: any, cssClass: any) {
+        static querySelectorAll_addCssClass(eParent: any, selector: string, cssClass: string) {
             var eRows = eParent.querySelectorAll(selector);
             for (var k = 0; k < eRows.length; k++) {
                 this.addCssClass(eRows[k], cssClass);
             }
         }
 
-        static querySelectorAll_removeCssClass(eParent: any, selector: any, cssClass: any) {
+        static querySelectorAll_removeCssClass(eParent: any, selector: string, cssClass: string) {
             var eRows = eParent.querySelectorAll(selector);
             for (var k = 0; k < eRows.length; k++) {
                 this.removeCssClass(eRows[k], cssClass);
             }
         }
 
-        static querySelectorAll_replaceCssClass(eParent: any, selector: any, cssClassToRemove: any, cssClassToAdd: any) {
+        static querySelectorAll_replaceCssClass(eParent: any, selector: string, cssClassToRemove: string, cssClassToAdd: string) {
             var eRows = eParent.querySelectorAll(selector);
             for (var k = 0; k < eRows.length; k++) {
                 this.removeCssClass(eRows[k], cssClassToRemove);
@@ -196,7 +198,7 @@ module awk.grid {
             }
         }
 
-        static addOrRemoveCssClass(element: any, className: any, addOrRemove: any) {
+        static addOrRemoveCssClass(element: HTMLElement, className: string, addOrRemove: boolean) {
             if (addOrRemove) {
                 this.addCssClass(element, className);
             } else {
@@ -204,7 +206,7 @@ module awk.grid {
             }
         }
 
-        static addCssClass(element: any, className: any) {
+        static addCssClass(element: HTMLElement, className: string) {
             if (element.className && element.className.length > 0) {
                 var cssClasses = element.className.split(' ');
                 if (cssClasses.indexOf(className) < 0) {
@@ -216,15 +218,15 @@ module awk.grid {
             }
         }
 
-        static offsetHeight(element: any) {
+        static offsetHeight(element: HTMLElement) {
             return element && element.clientHeight ? element.clientHeight : 0;
         }
 
-        static offsetWidth(element: any) {
+        static offsetWidth(element: HTMLElement) {
             return element && element.clientWidth ? element.clientWidth : 0;
         }
 
-        static removeCssClass(element: any, className: any) {
+        static removeCssClass(element: HTMLElement, className: string) {
             if (element.className && element.className.length > 0) {
                 var cssClasses = element.className.split(' ');
                 var index = cssClasses.indexOf(className);
@@ -235,7 +237,7 @@ module awk.grid {
             }
         }
 
-        static removeFromArray(array: any, object: any) {
+        static removeFromArray<T>(array: T[], object: T) {
             array.splice(array.indexOf(object), 1);
         }
 
@@ -261,7 +263,7 @@ module awk.grid {
             }
         }
 
-        static formatWidth(width: any) {
+        static formatWidth(width: number | string) {
             if (typeof width === "number") {
                 return width + "px";
             } else {
@@ -269,26 +271,30 @@ module awk.grid {
             }
         }
 
-        // tries to use the provided renderer. if a renderer found, returns true.
-        // if no renderer, returns false.
-        static useRenderer(eParent: any, eRenderer: any, params: any) {
+        /** 
+         * tries to use the provided renderer. if a renderer found, returns true.
+         * if no renderer, returns false.
+         */
+        static useRenderer<TParams>(eParent: Element, eRenderer: (params:TParams) => Node | string, params: TParams) {
             var resultFromRenderer = eRenderer(params);
-            if (this.isNode(resultFromRenderer) || this.isElement(resultFromRenderer)) {
-                //a dom node or element was returned, so add child
-                eParent.appendChild(resultFromRenderer);
-            } else {
-                //otherwise assume it was html, so just insert
+            //TypeScript type inference magic
+            if (typeof resultFromRenderer === 'string') {
                 var eTextSpan = document.createElement('span');
                 eTextSpan.innerHTML = resultFromRenderer;
                 eParent.appendChild(eTextSpan);
+            } else {
+                //a dom node or element was returned, so add child
+                eParent.appendChild(resultFromRenderer);
             }
         }
 
-        // if icon provided, use this (either a string, or a function callback).
-        // if not, then use the second parameter, which is the svgFactory function
-        static createIcon(iconName: any, gridOptionsWrapper: any, colDefWrapper: any, svgFactoryFunc: any) {
+        /** 
+         * if icon provided, use this (either a string, or a function callback).
+         * if not, then use the second parameter, which is the svgFactory function
+         */
+        static createIcon(iconName: any, gridOptionsWrapper: any, colDefWrapper: any, svgFactoryFunc: () => Node) {
             var eResult = document.createElement('span');
-            var userProvidedIcon: any;
+            var userProvidedIcon: Function | string;
             // check col for icon first
             if (colDefWrapper && colDefWrapper.colDef.icons) {
                 userProvidedIcon = colDefWrapper.colDef.icons[iconName];
@@ -352,12 +358,12 @@ module awk.grid {
             return widthNoScroll - widthWithScroll;
         }
 
-        static isKeyPressed(event: any, keyToCheck: any) {
+        static isKeyPressed(event: KeyboardEvent, keyToCheck: number) {
             var pressedKey = event.which || event.keyCode;
             return pressedKey === keyToCheck;
         }
 
-        static setVisible(element: any, visible: any) {
+        static setVisible(element: HTMLElement, visible: boolean) {
             if (visible) {
                 element.style.display = 'inline';
             } else {


### PR DESCRIPTION
Hi!

Created TypeScript type definition for ColDef based on the documentation and the code itself. In two or three cases TypeScript compiler couldn't figure out what to use from union types, so had to add a few explicit casts. Or had to reorder type checking so tsc can figure out the actual type used with union types. This union type handling should improve in TS 1.5.

Also added some  generics to the array/object iteration functions the utils.ts. Therefore some `any` typedefs could be could removed from the usage of those functions, but getting actual type safety based on the type of the array.

The generated javascript is pretty much the same as before, "dist" file not changed.
