### PR TITLE
Adding isInverted parameter to the signature of the column comparator

### DIFF
--- a/docs/angular-grid-sorting/index.php
+++ b/docs/angular-grid-sorting/index.php
@@ -41,7 +41,7 @@ include '../documentation_header.php';
     </p>
 
     <pre>
-colDef.comparator = function (value1, value2, data1, data2) {
+colDef.comparator = function (value1, value2, data1, data2, isInverted) {
     return value1 - value2;
 }</pre>
 

--- a/src/ts/rowControllers/inMemoryRowController.ts
+++ b/src/ts/rowControllers/inMemoryRowController.ts
@@ -337,12 +337,12 @@ module awk.grid {
 
             var that = this;
 
-            function compare(objA: any, objB: any, colDef: any) {
+            function compare(objA: any, objB: any, colDef: any, isInverted:any) {
                 var valueA = that.getValue(objA.data, colDef, objA);
                 var valueB = that.getValue(objB.data, colDef, objB);
                 if (colDef.comparator) {
                     //if comparator provided, use it
-                    return colDef.comparator(valueA, valueB, objA, objB);
+                    return colDef.comparator(valueA, valueB, objA, objB, isInverted);
                 } else {
                     //otherwise do our own comparison
                     return utils.defaultComparator(valueA, valueB);
@@ -353,7 +353,7 @@ module awk.grid {
                 // Iterate columns, return the first that doesn't match
                 for (var i = 0, len = sortOptions.length; i < len; i++) {
                     var sortOption = sortOptions[i];
-                    var compared = compare(objA, objB, sortOption.colDef);
+                    var compared = compare(objA, objB, sortOption.colDef, sortOption.inverter === -1);
                     if (compared !== 0) {
                         return compared * sortOption.inverter;
                     }


### PR DESCRIPTION
We have a use case where we are flattening a parent-child hierarchy in the grid. The custom sort treats all children as if they have the same values as their parent so when sorting children are always next to their parents. To do this we need to know if the sort is ASC or DESC as children need to always be below their parent no matter the direction of the sort