### PR TITLE
Add in default sort direction for a columnDef

### DIFF
--- a/docs/angular-grid-column-definitions/index.php
+++ b/docs/angular-grid-column-definitions/index.php
@@ -101,6 +101,10 @@ include '../documentation_header.php';
             <td>Set to true if no menu should be shown for this column header.</td>
         </tr>
         <tr>
+            <th>defaultSort</th>
+            <td>Set to "descending" to sort this column descending by default, else 'ascending'. If this isn't specified, it will default to 'ascending'.</td>
+        </tr>
+        <tr>
             <th>suppressSorting</th>
             <td>Set to true if no sorting should be done for this column.</td>
         </tr>

--- a/src/ts/headerRenderer.ts
+++ b/src/ts/headerRenderer.ts
@@ -390,7 +390,7 @@ module awk.grid {
                         return constants.DESC;
                     }
                 default :
-					return colDef.defaultSort && colDef.defaultSort === 'descending' ? constants.DESC : constants.ASC;
+					return colDef.defaultSort === 'descending' ? constants.DESC : constants.ASC;
             }
         }
 

--- a/src/ts/headerRenderer.ts
+++ b/src/ts/headerRenderer.ts
@@ -286,7 +286,7 @@ module awk.grid {
 
                 column.eSortAsc.style.display = 'none';
                 column.eSortDesc.style.display = 'none';
-                this.addSortHandling(headerCellLabel, column);
+                this.addSortHandling(headerCellLabel, column, colDef);
             }
 
             // add in filter icon
@@ -370,7 +370,7 @@ module awk.grid {
             }
         }
 
-        getNextSortDirection(direction: any) {
+        getNextSortDirection(direction: any, colDef: any) {
             var suppressUnSort = this.gridOptionsWrapper.isSuppressUnSort();
             var suppressDescSort = this.gridOptionsWrapper.isSuppressDescSort();
 
@@ -390,17 +390,17 @@ module awk.grid {
                         return constants.DESC;
                     }
                 default :
-                    return constants.ASC;
+					return colDef.defaultSort && colDef.defaultSort === 'descending' ? constants.DESC : constants.ASC;
             }
         }
 
-        addSortHandling(headerCellLabel: any, column: any) {
+        addSortHandling(headerCellLabel: any, column: any, colDef: any) {
             var that = this;
 
             headerCellLabel.addEventListener("click", function (e: any) {
 
                 // update sort on current col
-                column.sort = that.getNextSortDirection(column.sort);
+                column.sort = that.getNextSortDirection(column.sort, colDef);
 
                 // sortedAt used for knowing order of cols when multi-col sort
                 if (column.sort) {

--- a/src/ts/headerRenderer.ts
+++ b/src/ts/headerRenderer.ts
@@ -373,10 +373,11 @@ module awk.grid {
         getNextSortDirection(direction: any, colDef: any) {
             var suppressUnSort = this.gridOptionsWrapper.isSuppressUnSort();
             var suppressDescSort = this.gridOptionsWrapper.isSuppressDescSort();
-
+			var isDescendingByDefault = colDef.defaultSort === 'descending';
+			
             switch (direction) {
-                case constants.DESC:
-                    if (suppressUnSort) {
+                case constants.DESC:				
+                    if (suppressUnSort || isDescendingByDefault) {
                         return constants.ASC;
                     } else {
                         return null;
@@ -384,13 +385,13 @@ module awk.grid {
                 case constants.ASC:
                     if (suppressUnSort && suppressDescSort) {
                         return constants.ASC;
-                    } else if (suppressDescSort) {
+                    } else if (suppressDescSort || isDescendingByDefault) {
                         return null;
                     } else {
                         return constants.DESC;
                     }
-                default :
-					return colDef.defaultSort === 'descending' ? constants.DESC : constants.ASC;
+                default:
+					return isDescendingByDefault ? constants.DESC : constants.ASC;
             }
         }
 


### PR DESCRIPTION
I could find no way to tell the column to sort by descending by default. In our use case, we are showing a series of numbers and the higher the number is the more important the number is, so we want to show it first.

I was going to create a bug, but saw how easy this would be to add it via a columnDef, so just created the pull request first instead of a bug. 

I'm also not 100% sure why my commits came across as unknown :/