### PR TITLE
Add in default sort direction for a columnDef and suppressAscSort for gridOptions

### DIFF
--- a/docs/angular-grid-column-definitions/index.php
+++ b/docs/angular-grid-column-definitions/index.php
@@ -105,6 +105,10 @@ include '../documentation_header.php';
             <td>Set to true if no sorting should be done for this column.</td>
         </tr>
         <tr>
+            <th>defaultSort</th>
+            <td>Set to ASC, if the column should sort ascending by default, or DESC, if the default should be descending. Columns sort ASC by default.</td>
+        </tr>		
+        <tr>
             <th>unSortIcon</th>
             <td>Set to true if you want the unsorted icon to be shown when no sort is applied to this column.</td>
         </tr>

--- a/docs/angular-grid-grid-options/index.php
+++ b/docs/angular-grid-grid-options/index.php
@@ -84,6 +84,10 @@ include '../documentation_header.php';
             <td>Set to true or false. If true, sorting descending is disabled.</td>
         </tr>
         <tr>
+            <th>suppressAscSort</th>
+            <td>Set to true or false. If true, sorting ascending is disabled.</td>
+        </tr>
+        <tr>
             <th>unSortIcon</th>
             <td>Set to true to show the 'no sort' icon.</td>
         </tr>

--- a/src/ts/entities/colDef.ts
+++ b/src/ts/entities/colDef.ts
@@ -69,6 +69,9 @@ module awk.grid {
         /** Set to true if no sorting should be done for this column. */
         suppressSorting?: boolean;
 
+        /** Set to ASC, if the column should sort ascending by default, or DESC, if the default should be descending. Columns sort ASC by default. */
+        defaultSort?: string;
+
         /** Set to true if you want the unsorted icon to be shown when no sort is applied to this column. */
         unSortIcon?: boolean;
 

--- a/src/ts/entities/gridOptions.ts
+++ b/src/ts/entities/gridOptions.ts
@@ -22,6 +22,7 @@ module awk.grid {
         groupHeaders?: boolean;
         dontUseScrolls?: boolean;
         suppressDescSort?: boolean;
+        suppressAscSort?: boolean;
         unSortIcon?: boolean;
         rowStyle?: any;
         rowClass?: any;
@@ -77,5 +78,4 @@ module awk.grid {
         isScrollLag?(): boolean;
         suppressScrollLag?(): boolean;
     }
-
 }

--- a/src/ts/gridOptionsWrapper.ts
+++ b/src/ts/gridOptionsWrapper.ts
@@ -38,6 +38,7 @@ module awk.grid {
         isGroupHeaders() { return isTrue(this.gridOptions.groupHeaders); }
         isDontUseScrolls() { return isTrue(this.gridOptions.dontUseScrolls); }
         isSuppressDescSort() { return isTrue(this.gridOptions.suppressDescSort); }
+        isSuppressAscSort() { return isTrue(this.gridOptions.suppressAscSort); }
         isUnSortIcon() { return isTrue(this.gridOptions.unSortIcon); }
         getRowStyle() { return this.gridOptions.rowStyle; }
         getRowClass() { return this.gridOptions.rowClass; }

--- a/src/ts/rendering/renderedHeaderCell.ts
+++ b/src/ts/rendering/renderedHeaderCell.ts
@@ -252,25 +252,23 @@ module awk.grid {
         private getNextSortDirection() {
             var suppressUnSort = this.gridOptionsWrapper.isSuppressUnSort();
             var suppressDescSort = this.gridOptionsWrapper.isSuppressDescSort();
-
-            switch (this.column.sort) {
-                case constants.DESC:
-                    if (suppressUnSort) {
-                        return constants.ASC;
-                    } else {
-                        return null;
-                    }
-                case constants.ASC:
-                    if (suppressUnSort && suppressDescSort) {
-                        return constants.ASC;
-                    } else if (suppressDescSort) {
-                        return null;
-                    } else {
-                        return constants.DESC;
-                    }
-                default :
-                    return constants.ASC;
-            }
+            var suppressAscSort = this.gridOptionsWrapper.isSuppressAscSort();
+			var isDescendingByDefault = this.column.colDef.defaultSort === 'DESC';
+			
+			switch (this.column.sort) {
+				case constants.ASC: 
+					if (suppressUnSort) {
+						return suppressDescSort ? constants.ASC : constants.DESC;
+					}
+					return isDescendingByDefault ? null : constants.DESC;
+				case constants.DESC:
+					if (suppressUnSort) {
+						return suppressAscSort ? constants.DESC : constants.ASC;
+					}
+					return isDescendingByDefault ? constants.ASC : null;
+                default:
+					return isDescendingByDefault ? constants.DESC : constants.ASC;
+			}
         }
 
         private addSortHandling(headerCellLabel: HTMLElement) {


### PR DESCRIPTION
Adding in a default sort direction for a column and adding in a suppressAscSort for the grid options (to match the suppressDescSort, which helps clean up the logic).

In the use case this is needed for, we are showing a series of numbers and the higher the number is the more important it is, so our users want us to show it first.

Tested against the examples and everything appears to work. This is a duplicate of pull request #347, but done against the refactoring effort (which, by the way, I rather like more than it used to be. It was quite easy to find and make this change).