### PR TITLE
#363 Bug with SetFilters when newRowsAction as keep and selectAll checkbox selected

### DIFF
--- a/src/ts/filter/setFilter.ts
+++ b/src/ts/filter/setFilter.ts
@@ -116,8 +116,9 @@ module awk.grid {
 
         public onNewRowsLoaded(): void {
             var keepSelection = this.filterParams && this.filterParams.newRowsAction === 'keep';
+            var isSelectAll = this.eSelectAll && this.eSelectAll.checked && !this.eSelectAll.indeterminate;
             // default is reset
-            this.model.refreshUniqueValues(keepSelection);
+            this.model.refreshUniqueValues(keepSelection, isSelectAll);
             this.setContainerHeight();
             this.refreshVirtualRows();
         }

--- a/src/ts/filter/setFilterModel.ts
+++ b/src/ts/filter/setFilterModel.ts
@@ -32,7 +32,10 @@ module awk.grid {
             this.selectEverything();
         }
 
-        refreshUniqueValues(keepSelection: any) {
+        // if keepSelection not set will always select all filters
+        // if keepSelection set will keep current state of selected filters
+        //    unless selectAll chosen in which case will select all
+        refreshUniqueValues(keepSelection: any, isSelectAll: boolean) {
             this.createUniqueValues();
 
             var oldModel = Object.keys(this.selectedValuesMap);
@@ -41,7 +44,7 @@ module awk.grid {
             this.filterDisplayedValues();
 
             if (keepSelection) {
-                this.setModel(oldModel);
+                this.setModel(oldModel, isSelectAll);
             } else {
                 this.selectEverything();
             }
@@ -208,8 +211,8 @@ module awk.grid {
             return selectedValues;
         }
 
-        setModel(model: any) {
-            if (model) {
+        setModel(model: any, isSelectAll: boolean) {
+            if (model && !isSelectAll) {
                 this.selectNothing();
                 for (var i = 0; i < model.length; i++) {
                     var newValue = model[i];


### PR DESCRIPTION
SetFilter's with a newRowsAction of 'keep' should always select all filter values when the select All checkbox is checked.

To recreate the problem:
* rowdata = [{status:'A'}, {status:'B'}, {status:'C'}]
* Click filter menu on status column
* Uncheck select all
* Check select all
* Add new row to dataset {status:'D'}
* New row is not shown
* clicking on the filter menu shows status A.B,C selected and D unchecked
