### PR TITLE
Changed removeFromArray so it only removes "found" items

### DIFF
--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -232,7 +232,10 @@ module awk.grid {
         }
 
         static removeFromArray<T>(array: T[], object: T) {
-            array.splice(array.indexOf(object), 1);
+            if (array.indexOf(object) >= 0) {
+                array.splice(array.indexOf(object), 1);
+            }
+            
         }
 
         static defaultComparator(valueA: any, valueB: any) {


### PR DESCRIPTION
First of all, let me just say what a wonderful piece of software you have written! I am in the middle of a fairly large project and was having some issues with ui-grid, and was in fact thinking of creating a grid from scratch when I stumbled on to ag-grid. It blows away any ideas I had and I have incorporated it into my project beautifully. Thank you! 
As to this pull-request, it came about because I was having a problem when applying a filterModel (with api.setFilterModel). Tracing the problem, I found that within the function setFilterModel, as it iterates over "allFilters", it removes from "modelKeys" based on the "colid" (by calling Utils.removeFromArray). However, in the "removeFromArray" function, it splices the array based on the return of "indexOf". When indexOf does not find a "colid" inside the "modelKeys" array, it return -1 and splice is called with (-1, 1) which in fact removes the last element. I changed the removeFromArray function to check if the "object" being removed is in fact found within the array, before calling splice. This fixed my issue, and I believe makes the function act more according to its name, but if the removeFromArray function was in fact meant to remove the last element of the array if the "object" passed in was not found, I appologize and ask that you let me know.

Once again, thank you for this great component!!!