### PR TITLE
#398 Support scrolling on pinned columns

### DIFF
--- a/dist/angular-grid.d.ts
+++ b/dist/angular-grid.d.ts
@@ -1136,7 +1136,6 @@ declare module awk.grid {
         setPinnedColContainerWidth(): void;
         showPinnedColContainersIfNeeded(): void;
         setHeaderHeight(): void;
-        setPinnedColHeight(): void;
         setHorizontalScrollPosition(hScrollPosition: number): void;
         private addScrollListener();
         private requestDrawVirtualRows();

--- a/src/styles/angular-grid.styl
+++ b/src/styles/angular-grid.styl
@@ -125,7 +125,7 @@
     padding-right: 25px
     -ms-overflow-style: none !important
 
-.ag-pinned-header::-webkit-scrollbar
+.ag-pinned-cols-viewport::-webkit-scrollbar
     width: 0 !important
 
 .ag-pinned-cols-container

--- a/src/styles/angular-grid.styl
+++ b/src/styles/angular-grid.styl
@@ -38,6 +38,12 @@
     overflow: hidden
     height: 100%
 
+.ag-pinned-header 
+    box-sizing: border-box
+    display: inline-block
+    overflow: hidden
+    height: 100%
+
 .ag-header-viewport
     box-sizing: border-box
     display: inline-block
@@ -113,7 +119,14 @@
 .ag-pinned-cols-viewport
     float: left
     position: absolute
-    overflow: hidden
+    overflow-x: hidden
+    overflow-y: scroll
+    height: 100%
+    padding-right: 25px
+    -ms-overflow-style: none !important
+
+.ag-pinned-header::-webkit-scrollbar
+    width: 0 !important
 
 .ag-pinned-cols-container
     display: inline-block

--- a/src/ts/grid.ts
+++ b/src/ts/grid.ts
@@ -607,13 +607,12 @@ module awk.grid {
         }
 
         public doLayout() {
-            // need to do layout first, as drawVirtualRows and setPinnedColHeight
+            // need to do layout first, as drawVirtualRows
             // need to know the result of the resizing of the panels.
             var sizeChanged = this.eRootPanel.doLayout();
             // both of the two below should be done in gridPanel, the gridPanel should register 'resize' to the panel
             if (sizeChanged) {
                 this.rowRenderer.drawVirtualRows();
-                this.gridPanel.setPinnedColHeight();
             }
         }
     }

--- a/src/ts/gridPanel/gridPanel.ts
+++ b/src/ts/gridPanel/gridPanel.ts
@@ -310,14 +310,6 @@ module awk.grid {
             }
         }
 
-        // see if a grey box is needed at the bottom of the pinned col
-        public setPinnedColHeight() {
-            if (!this.forPrint) {
-                var bodyHeight = this.eBodyViewport.offsetHeight;
-                this.ePinnedColsViewport.style.height = bodyHeight + "px";
-            }
-        }
-
         public setHorizontalScrollPosition(hScrollPosition: number): void {
             this.eBodyViewport.scrollLeft = hScrollPosition;
         }

--- a/src/ts/gridPanel/gridPanel.ts
+++ b/src/ts/gridPanel/gridPanel.ts
@@ -288,6 +288,9 @@ module awk.grid {
             //some browsers had layout issues with the blank divs, so if blank,
             //we don't display them
             if (showingPinnedCols) {
+                // this allows CSS to target specific elements on the grid when showing pinned cols
+                utils.addCssClass(this.eRoot, 'ag-showing-pinned-cols');
+
                 this.ePinnedHeader.style.display = 'inline-block';
                 this.ePinnedColsViewport.style.display = 'inline';
             } else {
@@ -339,7 +342,7 @@ module awk.grid {
 
                 if (newTopPosition !== lastTopPosition) {
                     lastTopPosition = newTopPosition;
-                    this.scrollPinned(newTopPosition);
+                    _this.ePinnedColsViewport.scrollTop = newTopPosition;
                     this.requestDrawVirtualRows();
                 }
 
@@ -347,13 +350,10 @@ module awk.grid {
             });
 
             this.ePinnedColsViewport.addEventListener("scroll", () => {
-                // this means the pinned panel was moved, which can only
-                // happen when the user is navigating in the pinned container
-                // as the pinned col should never scroll. so we rollback
-                // the scroll on the pinned.
-                this.ePinnedColsViewport.scrollTop = 0;
+                // update body viewport with current scroll position
+                // this allows us to scroll on both pinned columns AND body
+                _this.eBodyViewport.scrollTop = _this.ePinnedColsViewport.scrollTop;
             });
-
         }
 
         private requestDrawVirtualRows() {
@@ -388,11 +388,6 @@ module awk.grid {
         private scrollHeader(bodyLeftPosition: any) {
             // this.eHeaderContainer.style.transform = 'translate3d(' + -bodyLeftPosition + "px,0,0)";
             this.eHeaderContainer.style.left = -bodyLeftPosition + "px";
-        }
-
-        private scrollPinned(bodyTopPosition: any) {
-            // this.ePinnedColsContainer.style.transform = 'translate3d(0,' + -bodyTopPosition + "px,0)";
-            this.ePinnedColsContainer.style.top = -bodyTopPosition + "px";
         }
     }
 }


### PR DESCRIPTION
Note: the CSS to hide scrollbar on the pinned column DIV isn't necessary for everything to work. Only in the case of scrolling very fast with the "scroll lag" feature on is it even possible to see the scroll bar for brief seconds. I used CSS to remove it for that case specifically. Just wanted to clarify, since we both know that won't work in every browser: that's OK.

Please merge this request in ASAP.