### PR TITLE
Expose renderedRows on gridApi

### DIFF
--- a/docs/angular-grid-api/index.php
+++ b/docs/angular-grid-api/index.php
@@ -150,6 +150,11 @@ include '../documentation_header.php';
             </td>
         </tr>
         <tr>
+            <th>getRenderedNodes()</th>
+            <td>Retrieve rendered nodes. Due to virtulisation this will contain only the current visible rows and the amount in the buffer.
+            </td>
+        </tr>
+        <tr>
             <th>showLoading(show)</th>
             <td>Show or hide the loading icon. Pass either true or false. If the method onNewRows
                 is called, the loading icon is automatically hidden.

--- a/src/ts/gridApi.ts
+++ b/src/ts/gridApi.ts
@@ -153,6 +153,10 @@ module awk.grid {
             return this.selectionController.getBestCostNodeSelection();
         }
 
+        public getRenderedNodes() {
+            return this.rowRenderer.getRenderedNodes();
+        }
+
         public ensureColIndexVisible(index:any) {
             this.gridPanel.ensureColIndexVisible(index);
         }

--- a/src/ts/rendering/rowRenderer.ts
+++ b/src/ts/rendering/rowRenderer.ts
@@ -276,6 +276,13 @@ module awk.grid {
             this.renderedRows[rowIndex] = renderedRow;
         }
 
+        public getRenderedNodes() {
+            var renderedRows = this.renderedRows;
+            return Object.keys(renderedRows).map(key => {
+                return renderedRows[key].getRowNode();
+            });
+        }
+
         public getIndexOfRenderedNode(node: any): number {
             var renderedRows = this.renderedRows;
             var keys: string[] = Object.keys(renderedRows);


### PR DESCRIPTION
Add getRenderedNodes to grid api. Use case for this is to update volatile columns only when their row is shown in the grid

http://www.angulargrid.com/forum/showthread.php?tid=2734