### PR TITLE
Make angular a dependency in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,5 +35,6 @@
   "devDependencies": {
   },
   "dependencies": {
+    "angular": "*"
   }
 }


### PR DESCRIPTION
This screws up things like wiredep, and it's really supposed to be there anyway.